### PR TITLE
Add issue templates

### DIFF
--- a/issue_template/bug_report.yml
+++ b/issue_template/bug_report.yml
@@ -1,6 +1,6 @@
 name: Report a bug
 description: File a bug/issue in this part of the project
-title: "[BUG] <title>"
+title: "[BUG]: <title>"
 labels: ["bug", "needs-triage"]
 body:
   - type: checkboxes

--- a/issue_template/bug_report.yml
+++ b/issue_template/bug_report.yml
@@ -1,0 +1,43 @@
+name: Report a bug
+description: File a bug/issue in this part of the project
+title: "[BUG] <title>"
+labels: ["bug", "needs-triage"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: A concise description of what you're experiencing.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expected to happen.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. With version ...
+        1. Using these configuration settings...
+        1. When running these commands...
+        1. See error...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/issue_template/bug_report.yml
+++ b/issue_template/bug_report.yml
@@ -41,3 +41,9 @@ body:
         Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
     validations:
       required: false
+  - type: input
+    attributes:
+      label: Search terms
+      description: Help other people discover your feature request by including other words they might search for.
+    validations:
+      required: true

--- a/issue_template/feature_request.yml
+++ b/issue_template/feature_request.yml
@@ -16,7 +16,7 @@ body:
       description: 
         A clear and concise description of the problem you have encountered to be solved.
       value: |
-        <!--- Describe your feature here --->
+        <!--- Describe your problem here --->
     validations:
       required: true
   - type: textarea

--- a/issue_template/feature_request.yml
+++ b/issue_template/feature_request.yml
@@ -1,0 +1,45 @@
+name: 🛠️ Feature Request
+description: Suggest an idea to improve something
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: checkboxes
+    attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the feature you are requesting.
+    options:
+      - label: I have searched the existing issues to confirm this is not a duplicate
+        required: true
+  - type: textarea
+    attributes:
+      label: Description of problem
+      description: 
+        A clear and concise description of the problem you have encountered to be solved.
+      value: |
+        <!--- Describe your feature here --->
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Suggested Solution
+      description: 
+        Describe the solution you'd like. A clear and concise description of what you want to happen. If you have
+        considered alternatives, please describe them.
+      value: |
+        <!--- Describe your solution here --->
+    validations:
+      required: false
+  - type: checkboxes
+    attributes:
+    label: Are you willing to work on this solution yourself?
+    description: As an all-volunteer organization, we are always looking for new contributors. Is this request something you are willing to contribute yourself?
+    options:
+      - label: I am willing to take on this work, once the community has had a chance to provide feedback. 
+	  - label: I am willing to do the work, but will need a mentor or guide.
+      - label: I cannot perform this work at this time. 
+  - type: input
+    attributes:
+      label: Search terms
+      description: Help other people discover your feature request by including other words they might search for.
+    validations:
+      required: true

--- a/issue_template/feature_request.yml
+++ b/issue_template/feature_request.yml
@@ -1,6 +1,6 @@
 name: 🛠️ Feature Request
 description: Suggest an idea to improve something
-title: "[Feature]: "
+title: "[Feature]: <title>"
 labels: ["enhancement", "needs-triage"]
 body:
   - type: checkboxes

--- a/issue_template/security_flaw.yml
+++ b/issue_template/security_flaw.yml
@@ -1,6 +1,6 @@
 name: Report a vulnerability
 description: File a bug/issue in this part of the project
-title: "[BUG] <title>"
+title: "[Security flaw]: <title>"
 labels: ["bug", "vulnerability", "needs-triage"]
 body:
   - type: markdown

--- a/issue_template/security_flaw.yml
+++ b/issue_template/security_flaw.yml
@@ -1,0 +1,19 @@
+name: Report a vulnerability
+description: File a bug/issue in this part of the project
+title: "[BUG] <title>"
+labels: ["bug", "vulnerability", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+		Security vulnerability reporting information for the AlmaLinux OS project is available on the AlmaLinux website. https://almalinux.org/p/vulnerability-disclosure-policy/
+		
+		Please follow the criteria below to ensure your report reaches the correct team.
+		
+		If you are not sure, please reach out to our security team for assistance. Please report vulnerabilities that require coordinated disclosure responsibly, no matter in which part of the project they are found. 
+		Contact: security@almalinux.org
+
+		If the flaw is in the operating system and but does not require coordinated disclosure, it may be reported in our bug tracker: 
+		Contact: https://bugs.almalinux.org
+
+		For any other flaws, please report them in the repository that is associated with the part of the project in question.


### PR DESCRIPTION
Adding 3 issue templates for the organization. These will be used automatically for every repo, unless a different template of the same name already exists for that repo. Overriding the defaults only requires creating your own in a specific repo. 