### PR TITLE
Add global feature request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,36 @@
+---
+name: Feature Request
+about: Suggest a new feature for AlmaLinux
+title: "[Feature Request] "
+labels: enhancement
+assignees: ''
+---
+
+## 🚀 Feature Description
+
+Describe the feature you are proposing. Be as specific as possible.
+
+---
+
+## 📋 Problem Statement
+
+What problem does this feature solve? Why is it needed?
+
+---
+
+## 🔍 Proposed Solution
+
+Explain how you think the problem should be addressed.
+
+---
+
+## 🧩 Alternatives Considered
+
+Have you considered any alternative solutions or workarounds?
+
+---
+
+## 📝 Additional Context
+
+Add any other context, screenshots, or references here.
+

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
This PR moves the feature request issue template originally proposed in:
https://github.com/AlmaLinux/almalinux.org/pull/819

It is now submitted to `.github` for global use across all AlmaLinux repositories, as requested by @bennyvasquez.
